### PR TITLE
Check if the outdir is writable to emit typescript definition file

### DIFF
--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -30,6 +30,7 @@ else
 endif
 
 TS_TEST_CASES = \
+	no_dir_permission \
     typescript_interface \
 	typescript_two_interfaces \
 	typescript_inheritance \
@@ -105,6 +106,14 @@ ifeq (node,$(JSENGINE))
 		$(_setup)
 		+$(swig_and_compile_cpp)
 		$(run_testcase)
+
+  no_dir_permission.cpptest no_dir_permission.ctest:
+		@echo "Executing swig to check if wrong directory generate an error"
+		$(eval RESULT := $(shell $(MAKE) -f $(top_builddir)/$(EXAMPLES)/Makefile SRCDIR='$(SRCDIR)' \
+		SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
+		SWIGOPT='-c++ -javascript $(SWIGOPT) -tstypes -outdir /tmp/nonexistingdir -o typescript_interface_wrap.cxx $(srcdir)/../typescript_interface.i' swiginvoke 2>&1))
+		@echo "$(RESULT)" | grep "No such file or directory" > /dev/null
+
 
   %.multicpptest:
 		$(_setup)

--- a/Examples/test-suite/typescript_import.i
+++ b/Examples/test-suite/typescript_import.i
@@ -4,11 +4,13 @@
 #include "typescript_d.h"
 %}
 
-%typemap(typescriptimports, noblock=1) SWIGTYPE {
-import { * } from './typescript-import-d-types';
+%pragma(javascript) tsimports=%{
+import { X } from './typescript-import-d-types';
+%}
 
-}
-
+%pragma(javascript) tsimports=%{
+import { D } from './typescript-import-d-types';
+%}
 
 %inline %{
 class C {
@@ -18,4 +20,5 @@ class C {
     D dValue;
 };
 %}
+
 

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -14,6 +14,7 @@
 #include <ctype.h>
 #include "swigmod.h"
 #include "cparse.h"
+#include "errno.h"
 
 /**
  * Enables extra debugging information in typemaps.
@@ -2695,6 +2696,10 @@ int TypeScriptTypes::top(Node *n) {
      String *moduleNameKebabCase = Swig_string_kebabcase(Getattr(n, "name"));
      String *typesFilePath = NewStringf("%s%s-types.d.ts", SWIG_output_directory(), moduleNameKebabCase);
      declarationFilePtr = NewFile(typesFilePath, "w", SWIG_output_files());
+     if ( !declarationFilePtr ) {
+       Printf(stderr, "Error opening file (%s) : %s\n", typesFilePath, strerror(errno));
+	     SWIG_exit(-1);
+     }
      Delete(typesFilePath);
      Delete(moduleNameKebabCase);
   }


### PR DESCRIPTION
Add a simple validation if the emitted file can be opened and if not, create an error.
I hate the way I created a test to prove it work. Maybe you can give me some hint of a cleaner way to do it