### PR TITLE
Emit proper function prototypes

### DIFF
--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -36,7 +36,8 @@ TS_TEST_CASES = \
 	typescript_inheritance \
 	typescript_multiple_inheritance \
 	typescript_import \
-	typescript_optional
+	typescript_optional \
+	typescript_methods
 
 CPP_TEST_CASES := $(TS_TEST_CASES)
 

--- a/Examples/test-suite/javascript/typescript_methods_runme.ts
+++ b/Examples/test-suite/javascript/typescript_methods_runme.ts
@@ -1,10 +1,16 @@
-import { C } from './typescript-methods-types';
+import { A, C } from './typescript-methods-types';
 
 const typescript_interface = require("./typescript_methods");
 
 const c: C = new typescript_interface.C();
+const cValue: C = {
+    intValue: 1,
+    floatValue: 2.3,
+};
 c.intValue = 3;
 c.floatValue = 2.45;
 const s = c.sum(2,3);
+c.funcWithStdString('Hello string function');
+const a: A = c.funcWithClass(new typescript_interface.C());
 
 process.exit(0);

--- a/Examples/test-suite/javascript/typescript_methods_runme.ts
+++ b/Examples/test-suite/javascript/typescript_methods_runme.ts
@@ -3,10 +3,6 @@ import { A, C } from './typescript-methods-types';
 const typescript_interface = require("./typescript_methods");
 
 const c: C = new typescript_interface.C();
-const cValue: C = {
-    intValue: 1,
-    floatValue: 2.3,
-};
 c.intValue = 3;
 c.floatValue = 2.45;
 const s = c.sum(2,3);

--- a/Examples/test-suite/javascript/typescript_methods_runme.ts
+++ b/Examples/test-suite/javascript/typescript_methods_runme.ts
@@ -1,0 +1,10 @@
+import { C } from './typescript-methods-types';
+
+const typescript_interface = require("./typescript_methods");
+
+const c: C = new typescript_interface.C();
+c.intValue = 3;
+c.floatValue = 2.45;
+const s = c.sum(2,3);
+
+process.exit(0);

--- a/Examples/test-suite/typescript_methods.i
+++ b/Examples/test-suite/typescript_methods.i
@@ -12,7 +12,7 @@ class C {
     float floatValue;
     int sum(int a,int b) { return a+b;}
     void funcWithStdString(std::string str) { }
-    A funcWithClass(C cVar) { }
+    A funcWithClass(C cVar) { return A(); }
 };
 %}
 

--- a/Examples/test-suite/typescript_methods.i
+++ b/Examples/test-suite/typescript_methods.i
@@ -1,0 +1,18 @@
+%module typescript_methods
+
+%inline %{
+
+class A {
+  std::string strValue;
+};
+
+class C {
+  public:
+    int intValue;
+    float floatValue;
+    int sum(int a,int b) { return a+b;}
+    void funcWithStdString(std::string str) { }
+    A funcWithClass(C cVar) { }
+};
+%}
+

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -2846,7 +2846,7 @@ int TypeScriptTypes::enumvalueDeclaration(Node *n)
  * As an example, for a C++ public function declared as:
  *   int sum(int a,int b) { return a+b;}
  * TypeScript emited will be:
- *   sum?(a:number, b:number) : number;
+ *   sum(a:number, b:number) : number;
  *
  * @param n The node that represents class member function
  * @return SWIG status
@@ -2857,7 +2857,7 @@ int TypeScriptTypes::memberfunctionHandler(Node *n)
   {
     String *functionName = Getattr(n, "sym:name");
     String *functionPrototype = NewString(functionName);
-    Append(functionPrototype,"?(");
+    Append(functionPrototype,"(");
     ParmList *l = Getattr(n, "parms");
     for (Parm* p = l; p; p = nextSibling(p)) {
       if ( p != l ) {

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -2838,7 +2838,15 @@ int TypeScriptTypes::enumvalueDeclaration(Node *n)
 
 /**
  * Handler executed in tree navigation when it encounters a class
- * member function
+ * member function.
+ *
+ * For TypeScript emits the prototype for the function wth returning type,
+ * parameters and corresponding parameters.
+ *
+ * As an example, for a C++ public function declared as:
+ *   int sum(int a,int b) { return a+b;}
+ * TypeScript emited will be:
+ *   sum?(a:number, b:number) : number;
  *
  * @param n The node that represents class member function
  * @return SWIG status
@@ -2851,17 +2859,14 @@ int TypeScriptTypes::memberfunctionHandler(Node *n)
     String *functionPrototype = NewString(functionName);
     Append(functionPrototype,"?(");
     ParmList *l = Getattr(n, "parms");
-    Parm *p;
-    int i;
-    for (i = 0, p = l; p; i++) {
-      if ( i > 0) {
-        Append(functionPrototype,", ");
+    for (Parm* p = l; p; p = nextSibling(p)) {
+      if ( p != l ) {
+        Append(functionPrototype, ", ");
       }
       Printf(functionPrototype, "%s:%s", Getattr(p,"name"), getTypescriptType(p));
       p = nextSibling(p);
     }
-    String *typescriptType = getTypescriptType(n);
-    Printf(functionPrototype, ") : %s;", typescriptType);
+    Printf(functionPrototype, ") : %s;", getTypescriptType(n));
     tsTypeInterfaceDeclaration->addMemberFunction(functionName, functionPrototype);
   }
   return Language::memberfunctionHandler(n);


### PR DESCRIPTION
Last version emited public functions to interface definition without return value and proper parameter definitions.
This modification aims to emit the corresponding complete typescript method prototype.